### PR TITLE
fix: Temporarily disable host password decryption in create_host_from…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,5 +8,24 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools.dynamic]
 dependencies = { file = ["requirements.txt"] }
 
+[project]
+name = "pytest-mfd-config"
+description = "Pytest Plugin that handles test and topology configs and all their belongings like helper fixtures."
+requires-python = ">=3.10, <3.14"
+version = "3.26.0"
+dynamic = ["dependencies"]
+license-files = ["LICENSE.md", "AUTHORS.md"]
+readme = {file = "README.md", content-type = "text/markdown"}
+classifiers=["Framework :: Pytest"]
+
+[project.urls]
+Homepage = "https://github.com/intel/mfd"
+Repository = "https://github.com/intel/pytest-mfd-config"
+Issues = "https://github.com/intel/pytest-mfd-config/issues"
+Changelog = "https://github.com/intel/pytest-mfd-config/blob/main/CHANGELOG.md"
+
 [tool.setuptools.packages.find]
 exclude = ["examples", "tests*", "sphinx-doc"]
+
+[project.entry-points.pytest11]
+pytest_mfd_config = "pytest_mfd_config.fixtures"

--- a/pytest_mfd_config/fixtures.py
+++ b/pytest_mfd_config/fixtures.py
@@ -291,7 +291,7 @@ def create_host_from_model(host_model: "HostModel", cli_client: Optional["CliCli
     when "instantiate" flag is set to False.
     :return: Host object
     """
-    host_model = _decrypt_host_password(host_model)
+    # host_model = _decrypt_host_password(host_model) # todo fix decryption of host passwords
     _connections = create_host_connections_from_model(host_model)
 
     connections = Connections(_connections=_connections)
@@ -550,6 +550,8 @@ def _has_secret_password_fields(connections: Any) -> bool:
     for connection in connections:
         if connection.connection_options:
             for key, value in connection.connection_options.items():
+                # todo, password is always SecretStr from model point of view
+                # even it's not encrypted
                 if "password" in key.lower() and isinstance(value, SecretStr):
                     logger.log(
                         level=log_levels.MODULE_DEBUG,


### PR DESCRIPTION
This pull request makes minor adjustments related to password handling in the `pytest_mfd_config/fixtures.py` file. The main changes involve temporarily disabling host password decryption and clarifying the handling of password fields in connection options.

Password handling adjustments:

* Commented out the call to `_decrypt_host_password` in the `create_host_from_model` function, with a note to fix host password decryption in the future.
* Added a comment in the `_has_secret_password_fields` function to clarify that password fields are always `SecretStr` from the model's perspective, even if not encrypted.