### PR TITLE
feat: Decrypt passwords for topology objects (Switch, PowerMng, OSD)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ All of them can be find in `pytest_mfd_config.fixtures.py` file.
 - `create_host_connections_from_model(host_model: HostModel) -> List[AsyncConnection]` - Prepare list of mfd-connect connections from model data.
 - `create_switch_from_model(switch_model: SwitchModel) -> Switch` - Prepare Switch object from model data.
 - `create_power_mng_from_model(power_mng_model: PowerMngModel) -> PowerManagement` - Prepare PowerManagement object from model data.
+- `create_osd_controller_from_model(osd_controller_model: OSDControllerModel) -> OsdController` - Prepare OSD controller object from model data.
 - `get_connection_object(connection_model: "ConnectionModel", connection_list: List["AsyncConnection"] = None, relative_connection: "AsyncConnection" = None,) -> "AsyncConnection"` - Prepare connection object from model data, relative connection is used for `SerialConnection`, connection_list or relative_connection must be passed in case of `SerialConnection`  
 
 #### How to instantiate Host / How to update `hosts` fixture dictionary? 
@@ -406,6 +407,13 @@ class PowerMngModel(BaseModel):
     community_string: Optional[str] = None
     outlet_number: Optional[int] = None
 ```  
+
+  #### PowerMng password decryption
+
+  Field `PowerMngModel.password` can be stored in encrypted form (Fernet). During Power Management object creation, this value is automatically decrypted using `AMBER_ENCRYPTION_KEY`.
+
+  Example of usage: `examples\topology_host_config_with_secrets.yaml`.
+
 #### Secrets
 Topology supports hiding secrets from logs. E.g. every model that inherits from MachineModel class has `mng_password` field, which is of type SecretStr.
 If printed, this field would be visible as `SecretStr("********")`, to get value use `get_secret_value()`
@@ -427,6 +435,12 @@ class OSDControllerModel(BaseModel):
     secured: bool | None = True
     proxies: Dict[str, str] | None = None
 ```
+
+  #### OSD password decryption
+
+  Field `OSDControllerModel.password` can be stored in encrypted form (Fernet). During OSD controller object creation, this value is automatically decrypted using `AMBER_ENCRYPTION_KEY`.
+
+  Example of usage: `examples\topology_host_config_with_secrets.yaml`.
 
 ### SwitchModel
 
@@ -452,6 +466,12 @@ switches:                                 # switches details needed for mfd-swit
   vlans: ['111', '112', '113']
 - (...)
 ```
+
+#### Switch password decryption
+
+Password fields (`mng_password`, `enable_password`) in `SwitchModel` can be stored in encrypted form (Fernet). During Switch object creation, decryption is attempted for password values represented as `SecretStr`, using the key from the `AMBER_ENCRYPTION_KEY` environment variable when it is available. If a value is not actually encrypted, or if `AMBER_ENCRYPTION_KEY` is missing, the original value is returned.
+
+Example of usage: `examples\topology_host_config_with_secrets.yaml`.
 
 ### ServiceModel
 - List of services like DHCP, NSX test automation may want to use during tests

--- a/examples/topology_host_config_with_secrets.yaml
+++ b/examples/topology_host_config_with_secrets.yaml
@@ -3,7 +3,7 @@ metadata:                           # mandatory
   version: '2.4'
 hosts:                              # each of the element of the topology_configs file is optional, but once provided we validate whether mandatory params are provided
 - name: sut                         # mandatory
-  instantiate: true                  # mandatory - determines whether Host object should be instantiated when using fixture
+  instantiate: true                 # mandatory - determines whether Host object should be instantiated when using fixture
   role: sut                         # mandatory
   connections:                      # optional
   - ip_address: {{ ip_address }}
@@ -12,6 +12,58 @@ hosts:                              # each of the element of the topology_config
     connection_type: SSHConnection
     connection_options:
       username: {{ 'root' if 'posix' in system.lower() else 'berta' }}
-      password: {{ secrets_password }}  # <------ Here you have provided name of the secret, not the value.
-  - ip_address: 127.0.0.1               # The value will be retrieved from the secrets manager and injected into the connection options.
+      password: {{ secret_password }}  # <------ Here you have provided name of the secret, not the value. The value will be retrieved from the secrets manager and injected into the connection options.
+  - ip_address: 127.0.0.1
     connection_type: LocalConnection
+- name: sut-2                       # mandatory
+  instantiate: true                 # mandatory - determines whether Host object should be instantiated when using fixture
+  role: sut                         # mandatory
+  connections:                      # optional
+  - ip_address: {{ ip_address }}
+    connection_type: SSHConnection
+    connection_options:
+      username: {{ 'root' if 'posix' in system.lower() else 'berta' }}
+      password: {{ plain_password }}
+- name: sut-3                     # mandatory
+  instantiate: false                # mandatory - determines whether Host object should be instantiated when using fixture
+  role: sut                         # mandatory
+  connections:                      # optional
+  - mac_address: {{ mac_address }}
+    connection_type: RPyCConnection
+    osd_details:
+      base_url: http://example.com/osd
+      username: root
+      password: {{ secret_password }}  # Secret password that needs to be decrypted (AMBER_ENCRYPTION_KEY needs to be set to do this)
+switches:
+- name: Dell ZF 1223456
+  mng_ip_address: 10.1.2.4
+  mng_user: foo
+  mng_password: {{ secret_password }}  # Secret password that needs to be decrypted (AMBER_ENCRYPTION_KEY needs to be set to do this)
+  instantiate: false
+  switch_type: DellOS9_Force10
+  device_type: Dell
+  connection_type: SSHSwitchConnection
+  power_mng:
+    power_mng_type: Ipmi
+    host: host
+    username: root
+    password: {{ secret_password }}
+    connection:
+      ip_address: 10.1.0.3
+      connection_type: RPyCConnection
+- name: Mellanox ZF XYZ
+  mng_ip_address: 10.1.2.3
+  mng_user: foo
+  mng_password: pass
+  instantiate: false
+  switch_type: DellOS9_Force10
+  device_type: Dell
+  connection_type: SSHSwitchConnection
+  power_mng:
+    power_mng_type: Ipmi
+    host: host
+    username: root
+    password: {{ plain_password }}
+    connection:
+      ip_address: 10.1.0.4
+      connection_type: RPyCConnection

--- a/pytest_mfd_config/fixtures.py
+++ b/pytest_mfd_config/fixtures.py
@@ -115,6 +115,8 @@ def create_switch_from_model(switch_model: SwitchModel) -> "Switch":
     """
     logger.log(level=log_levels.MODULE_DEBUG, msg="Preparing Switch object based on model.")
 
+    switch_model = _decrypt_switch_password(switch_model)
+
     import mfd_switchmanagement  # noqa: F401
     from mfd_switchmanagement import SSHSwitchConnection, CiscoAPIConnection
 
@@ -215,11 +217,7 @@ def _establish_connection(
     if connection_model.ip_address:
         options["ip"] = str(connection_model.ip_address)
     elif connection_model.mac_address:
-        from mfd_osd_control import OsdController
-
-        osd_details: Dict[str, Any] = connection_model.osd_details.dict()
-        osd_details["password"] = osd_details["password"].get_secret_value() if osd_details.get("password") else None
-        osd_controller = OsdController(**osd_details)
+        osd_controller = create_osd_controller_from_model(connection_model.osd_details)
 
         if not osd_controller.does_host_exist(connection_model.mac_address):
             raise PyTestMFDConfigException(f"Passed OSD Host does not exist! {connection_model.osd_details}")
@@ -265,7 +263,10 @@ def create_power_mng_from_model(power_mng_model: PowerMngModel) -> "PowerManagem
     """
     logger.log(level=log_levels.MODULE_DEBUG, msg="Preparing power management object.")
 
+    power_mng_model = _decrypt_model_password(power_mng_model, field_name="password")
+
     import mfd_powermanagement
+    import mfd_powermanagement.pdu
 
     power_mng_class = getattr(mfd_powermanagement, power_mng_model.power_mng_type)
 
@@ -278,6 +279,27 @@ def create_power_mng_from_model(power_mng_model: PowerMngModel) -> "PowerManagem
     if power_mng_model.connection is not None and not issubclass(power_mng_class, mfd_powermanagement.pdu.PDU):
         power_mng_kwargs["connection"] = get_connection_object(power_mng_model.connection)
     return power_mng_class(**power_mng_kwargs)
+
+
+def create_osd_controller_from_model(osd_controller_model: Any) -> Any:
+    """
+    Create OSD Controller object based on data from model.
+
+    :param osd_controller_model: OSD Controller model object.
+    :return: OSD Controller object.
+    """
+    logger.log(level=log_levels.MODULE_DEBUG, msg="Preparing OSD Controller object.")
+
+    from mfd_osd_control import OsdController
+
+    osd_controller_model = _decrypt_model_password(osd_controller_model, field_name="password")
+    osd_controller_details = osd_controller_model.dict()
+
+    password = osd_controller_details.get("password")
+    if isinstance(password, SecretStr):
+        osd_controller_details["password"] = password.get_secret_value()
+
+    return OsdController(**osd_controller_details)
 
 
 def create_host_from_model(host_model: "HostModel", cli_client: Optional["CliClient"] = None) -> Host:
@@ -330,6 +352,167 @@ def hosts(topology: TopologyModel) -> Dict[str, Host]:
             host = create_host_from_model(host_model=host_model)
             hosts_dict[host.name] = host
     return hosts_dict
+
+
+def _try_decrypt_secret(value: SecretStr | str | None, cipher: "Fernet") -> SecretStr:
+    """
+    Try to decrypt a Fernet-encrypted SecretStr.
+
+    Returns a new SecretStr with the plaintext on success,
+    or the original value unchanged if it was not encrypted.
+
+    :param value: SecretStr, str, or None to decrypt
+    :param cipher: Fernet cipher object
+    :return: Decrypted SecretStr or original value unchanged
+    """
+    try:
+        decrypted = cipher.decrypt(value.get_secret_value().encode("utf-8")).decode()
+        return SecretStr(decrypted)
+    except InvalidToken:
+        logger.log(
+            level=log_levels.MODULE_DEBUG,
+            msg="Value for 'password' is not a valid Fernet token. Keeping original value.",
+        )
+        return value
+    except AttributeError:
+        return value
+
+
+def _has_secret_switch_password_fields(switch_model: SwitchModel) -> bool:
+    """Check whether switch has any SecretStr password field to decrypt.
+
+    :param switch_model: SwitchModel object
+    :return: True if at least one password field is a SecretStr, False otherwise
+    """
+    return isinstance(getattr(switch_model, "mng_password", None), SecretStr) or isinstance(
+        getattr(switch_model, "enable_password", None), SecretStr
+    )
+
+
+def _decrypt_switch_password(switch_model: SwitchModel) -> SwitchModel:
+    """
+    Decrypt password fields in a SwitchModel.
+
+    If `mng_password` or `enable_password` is a Fernet-encrypted value,
+    it will be decrypted and replaced with a new SecretStr containing the plaintext.
+
+    :param switch_model: SwitchModel object
+    :return: SwitchModel with decrypted password fields
+    """
+    if not _has_secret_switch_password_fields(switch_model):
+        return switch_model
+
+    try:
+        cipher = _get_encryption_obj()
+    except PyTestMFDConfigException as info:
+        logger.log(level=log_levels.MODULE_DEBUG, msg=info)
+        return switch_model
+
+    updates = {}
+    for field in ("mng_password", "enable_password"):
+        value = getattr(switch_model, field, None)
+        decrypted = _try_decrypt_secret(value, cipher)
+        if decrypted is not value:
+            logger.log(
+                level=log_levels.MODULE_DEBUG,
+                msg=f"Decrypting '{field}' for switch: {switch_model.mng_ip_address}",
+            )
+            updates[field] = decrypted
+    if updates:
+        return switch_model.model_copy(update=updates)
+    return switch_model
+
+
+def _decrypt_host_password(host_model: "HostModel") -> "HostModel":
+    """
+    Decrypt password fields for a HostModel.
+
+    Decrypts host-level `mng_password` and password-like values in
+    `connection_options` for all host connections.
+    """
+    has_connection_passwords = any(
+        connection.connection_options and any("password" in key.lower() for key in connection.connection_options)
+        for connection in (host_model.connections or [])
+    )
+    has_mng_password = isinstance(getattr(host_model, "mng_password", None), SecretStr)
+
+    if not has_connection_passwords and not has_mng_password:
+        if not host_model.connections:
+            logger.log(level=log_levels.MODULE_DEBUG, msg=f"No connections for host: {host_model.name}, skipping.")
+        return host_model
+
+    try:
+        cipher = _get_encryption_obj()
+    except PyTestMFDConfigException as e:
+        logger.log(level=log_levels.MODULE_DEBUG, msg=e)
+        return host_model
+
+    updates = {}
+    if has_mng_password:
+        mng_key = "mng_password"
+        mng_password = getattr(host_model, mng_key, None)
+        decrypted = _try_decrypt_secret(mng_password, cipher)
+        if decrypted is not mng_password:
+            logger.log(
+                level=log_levels.MODULE_DEBUG,
+                msg=f"Decrypting '{mng_key}' for host: {host_model.name}",
+            )
+            updates[mng_key] = decrypted
+
+    updated_connections = []
+    for connection in host_model.connections or []:
+        if not connection.connection_options:
+            updated_connections.append(connection)
+            continue
+        new_options = {}
+        for key, value in connection.connection_options.items():
+            if "password" in key.lower() and isinstance(value, SecretStr):
+                decrypted = _try_decrypt_secret(value, cipher)
+                if decrypted is not value:
+                    logger.log(
+                        level=log_levels.MODULE_DEBUG,
+                        msg=f"Decrypting '{key}' for host: {host_model.name}",
+                    )
+                new_options[key] = decrypted
+            else:
+                new_options[key] = value
+        updated_connections.append(connection.model_copy(update={"connection_options": new_options}))
+
+    if host_model.connections is not None:
+        updates["connections"] = updated_connections
+
+    if updates:
+        return host_model.model_copy(update=updates)
+    return host_model
+
+
+def _decrypt_model_password(model: Any, field_name: str = "password") -> Any:
+    """
+    Decrypt a password field in a model (e.g., PowerMngModel, OSDControllerModel).
+
+    If the field is a Fernet-encrypted SecretStr, it will be decrypted and
+    replaced with a new SecretStr containing plaintext.
+
+    :param model: Model object with a password field
+    :param field_name: Name of the password field (default: "password")
+    :return: Model with decrypted password field
+    """
+    password = getattr(model, field_name, None)
+    if password is None:
+        return model
+
+    try:
+        cipher = _get_encryption_obj()
+    except PyTestMFDConfigException as info:
+        logger.log(level=log_levels.MODULE_DEBUG, msg=info)
+        return model
+
+    decrypted = _try_decrypt_secret(password, cipher)
+    if decrypted is password:
+        return model
+
+    logger.log(level=log_levels.MODULE_DEBUG, msg=f"Decrypting '{field_name}' in {type(model).__name__}")
+    return model.model_copy(update={field_name: decrypted})
 
 
 """Test Config methods."""
@@ -538,54 +721,6 @@ def _get_secrets(test_config: dict) -> dict[str, SecretModel]:
     else:
         logger.log(level=log_levels.MODULE_DEBUG, msg="There is no 'secrets' key in test config file.")
         return {}
-
-
-def _decrypt_host_password(host_model: "HostModel") -> "HostModel":
-    """
-    Decrypt password fields in connection_options for all connections of a HostModel.
-
-    Any field containing 'password' in connection_options that is a Fernet-encrypted value
-    will be decrypted and replaced with a new SecretStr containing the plaintext.
-
-    :param host_model: HostModel object
-    :return: HostModel with decrypted password fields in connection_options
-    :raises PyTestMFDConfigException: If AMBER_ENCRYPTION_KEY is not set in environment variables
-    """
-    if not host_model.connections:
-        logger.log(level=log_levels.MODULE_DEBUG, msg=f"No connections for host: {host_model.name}, skipping.")
-        return host_model
-
-    try:
-        cipher = _get_encryption_obj()
-    except PyTestMFDConfigException:
-        return host_model
-
-    updated_connections = []
-    for connection in host_model.connections:
-        if not connection.connection_options:
-            updated_connections.append(connection)
-            continue
-        new_options = {}
-        for key, value in connection.connection_options.items():
-            if "password" in key.lower() and isinstance(value, SecretStr):
-                logger.log(
-                    level=log_levels.MODULE_DEBUG,
-                    msg=f"Trying to decrypt '{key}' in connection_options for host: {host_model.name}",
-                )
-                encrypted = value.get_secret_value().encode("utf-8")
-                try:
-                    decrypted = cipher.decrypt(encrypted).decode()
-                    new_options[key] = SecretStr(decrypted)
-                except InvalidToken:
-                    logger.log(
-                        level=log_levels.MODULE_DEBUG,
-                        msg=f"Value for '{key}' is not a valid Fernet token. Keeping original value.",
-                    )
-                    new_options[key] = value
-            else:
-                new_options[key] = value
-        updated_connections.append(connection.model_copy(update={"connection_options": new_options}))
-    return host_model.model_copy(update={"connections": updated_connections})
 
 
 def _get_encryption_obj() -> Fernet:

--- a/tests/unit/test_pytest_mfd_config/test_fixtures.py
+++ b/tests/unit/test_pytest_mfd_config/test_fixtures.py
@@ -5,6 +5,8 @@
 import logging
 import os
 import re
+import sys
+import types
 
 from pydantic import SecretStr
 
@@ -17,16 +19,26 @@ from ruamel.yaml import YAML
 from pytest_mfd_config.exceptions import PyTestMFDConfigException
 from pytest_mfd_config.fixtures import (
     _get_connected_pairs,
+    _establish_connection,
+    hosts,
     log_extra_data_after_test,
+    create_switch_from_model,
     get_connection_object,
+    create_osd_controller_from_model,
+    create_power_mng_from_model,
+    _try_decrypt_secret,
     pass_parameters_from_config_file,
     parse_overwrite,
     _get_secrets,
     _get_encryption_obj,
     _decrypt_secrets,
     _decrypt_host_password,
+    _decrypt_switch_password,
+    _has_secret_switch_password_fields,
     create_host_from_model,
+    _decrypt_model_password,
 )
+from pytest_mfd_config.models.topology import SwitchModel
 from mfd_host import Host
 from pytest_mfd_config.models.test_config import HostPairConnectionModel, SecretModel
 from pytest_mfd_config.models.topology import ConnectionModel
@@ -365,9 +377,72 @@ class TestFixtures:
         result = _decrypt_host_password(host_model)
 
         decrypted_options = result.connections[0].connection_options
+        assert "password" in decrypted_options
         assert decrypted_options["password"].get_secret_value() == "plain_password"
         assert decrypted_options["jump_host_password"].get_secret_value() == "plain_jump_password"
         assert decrypted_options["timeout"] == 30
+        assert mock_cipher.decrypt.call_count == 2
+
+    def test__has_secret_switch_password_fields_no_secrets(self, mocker):
+        switch_model = mocker.Mock(spec=SwitchModel)
+        switch_model.mng_password = None
+        switch_model.enable_password = None
+        switch_model.mng_ip_address = "10.0.0.1"
+
+        assert _has_secret_switch_password_fields(switch_model) is False
+
+    def test__has_secret_switch_password_fields_mng_password(self, mocker):
+        switch_model = mocker.Mock(spec=SwitchModel)
+        switch_model.mng_password = SecretStr("encrypted")
+        switch_model.enable_password = None
+        switch_model.mng_ip_address = "10.0.0.1"
+
+        assert _has_secret_switch_password_fields(switch_model) is True
+
+    def test__has_secret_switch_password_fields_enable_password(self, mocker):
+        switch_model = mocker.Mock(spec=SwitchModel)
+        switch_model.mng_password = None
+        switch_model.enable_password = SecretStr("encrypted")
+        switch_model.mng_ip_address = "10.0.0.1"
+
+        assert _has_secret_switch_password_fields(switch_model) is True
+
+    def test__decrypt_switch_password_no_decryption_needed(self, mocker):
+        switch_model = mocker.Mock(spec=SwitchModel)
+        switch_model.mng_password = None
+        switch_model.enable_password = None
+        switch_model.mng_ip_address = "10.0.0.1"
+
+        get_encryption_obj = mocker.patch("pytest_mfd_config.fixtures._get_encryption_obj")
+
+        result = _decrypt_switch_password(switch_model)
+
+        assert result is switch_model
+        get_encryption_obj.assert_not_called()
+
+    def test__decrypt_switch_password_decrypts_both_fields(self, mocker):
+        class DummySwitch:
+            def __init__(self):
+                self.mng_password = SecretStr("encrypted_mng")
+                self.enable_password = SecretStr("encrypted_enable")
+                self.mng_ip_address = "10.0.0.1"
+
+            def model_copy(self, update):
+                obj = DummySwitch()
+                for k, v in update.items():
+                    setattr(obj, k, v)
+                return obj
+
+        switch_model = DummySwitch()
+
+        mock_cipher = mocker.Mock()
+        mock_cipher.decrypt.side_effect = [b"plain_mng", b"plain_enable"]
+        mocker.patch("pytest_mfd_config.fixtures._get_encryption_obj", return_value=mock_cipher)
+
+        result = _decrypt_switch_password(switch_model)
+
+        assert result.mng_password.get_secret_value() == "plain_mng"
+        assert result.enable_password.get_secret_value() == "plain_enable"
         assert mock_cipher.decrypt.call_count == 2
 
     def test__decrypt_host_password_invalid_token_keeps_original(self, mocker):
@@ -462,3 +537,301 @@ class TestFixtures:
 
         mock_host.refresh_network_interfaces.assert_called_once()
         assert result is mock_host
+
+    def test__decrypt_model_password_decrypts_power_mng_password(self, mocker):
+        class DummyPowerMng:
+            def __init__(self):
+                self.password = SecretStr("encrypted_password")
+
+            def model_copy(self, update):
+                obj = DummyPowerMng()
+                for k, v in update.items():
+                    setattr(obj, k, v)
+                return obj
+
+        power_mng_model = DummyPowerMng()
+
+        mock_cipher = mocker.Mock()
+        mock_cipher.decrypt.return_value = b"plain_password"
+        mocker.patch("pytest_mfd_config.fixtures._get_encryption_obj", return_value=mock_cipher)
+
+        result = _decrypt_model_password(power_mng_model, field_name="password")
+
+        assert result.password.get_secret_value() == "plain_password"
+        mock_cipher.decrypt.assert_called_once_with(b"encrypted_password")
+
+    def test__decrypt_model_password_without_power_mng_password(self, mocker):
+        class DummyPowerMng:
+            def __init__(self):
+                self.password = None
+
+        power_mng_model = DummyPowerMng()
+
+        get_encryption_obj = mocker.patch("pytest_mfd_config.fixtures._get_encryption_obj")
+        result = _decrypt_model_password(power_mng_model, field_name="password")
+
+        assert result is power_mng_model
+        get_encryption_obj.assert_not_called()
+
+    def test__decrypt_model_password_decrypts_osd_controller_password(self, mocker):
+        class DummyOSDController:
+            def __init__(self):
+                self.password = SecretStr("encrypted_password")
+
+            def model_copy(self, update):
+                obj = DummyOSDController()
+                for k, v in update.items():
+                    setattr(obj, k, v)
+                return obj
+
+        osd_controller_model = DummyOSDController()
+
+        mock_cipher = mocker.Mock()
+        mock_cipher.decrypt.return_value = b"plain_password"
+        mocker.patch("pytest_mfd_config.fixtures._get_encryption_obj", return_value=mock_cipher)
+
+        result = _decrypt_model_password(osd_controller_model, field_name="password")
+
+        assert result.password.get_secret_value() == "plain_password"
+        mock_cipher.decrypt.assert_called_once_with(b"encrypted_password")
+
+    def test__decrypt_model_password_without_osd_controller_password(self, mocker):
+        class DummyOSDController:
+            def __init__(self):
+                self.password = None
+
+        osd_controller_model = DummyOSDController()
+
+        get_encryption_obj = mocker.patch("pytest_mfd_config.fixtures._get_encryption_obj")
+        result = _decrypt_model_password(osd_controller_model, field_name="password")
+
+        assert result is osd_controller_model
+        get_encryption_obj.assert_not_called()
+
+    def test_create_osd_controller_from_model_uses_decrypted_password(self, mocker):
+        captured = {}
+
+        class DummyOsdController:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        dummy_osd_mod = types.ModuleType("mfd_osd_control")
+        dummy_osd_mod.OsdController = DummyOsdController
+        mocker.patch.dict(sys.modules, {"mfd_osd_control": dummy_osd_mod})
+
+        class DummyModel:
+            def dict(self):
+                return {
+                    "base_url": "http://osd",
+                    "username": "user",
+                    "password": SecretStr("plain_password"),
+                    "secured": True,
+                    "proxies": None,
+                }
+
+        model = DummyModel()
+        decrypt_mock = mocker.patch("pytest_mfd_config.fixtures._decrypt_model_password", return_value=model)
+
+        result = create_osd_controller_from_model(model)
+
+        assert isinstance(result, DummyOsdController)
+        decrypt_mock.assert_called_once_with(model, field_name="password")
+        assert captured["password"] == "plain_password"
+
+    def test_create_power_mng_from_model_uses_decrypted_password(self, mocker):
+        class DummyPowerMngClass:
+            def __init__(self, ip=None, password=None, **kwargs):
+                self.kwargs = {"ip": ip, "password": password, **kwargs}
+
+        class DummyPowerModel:
+            power_mng_type = "DummyPowerMngClass"
+            connection = None
+
+            def dict(self):
+                return {"power_mng_type": "DummyPowerMngClass", "ip": "10.0.0.2", "password": "plain_pass"}
+
+        dummy_pdu_mod = types.ModuleType("mfd_powermanagement.pdu")
+        dummy_pdu_mod.PDU = type("PDU", (), {})
+
+        dummy_power_mod = types.ModuleType("mfd_powermanagement")
+        dummy_power_mod.DummyPowerMngClass = DummyPowerMngClass
+        dummy_power_mod.pdu = dummy_pdu_mod
+
+        mocker.patch.dict(
+            sys.modules,
+            {
+                "mfd_powermanagement": dummy_power_mod,
+                "mfd_powermanagement.pdu": dummy_pdu_mod,
+            },
+        )
+        mocker.patch("pytest_mfd_config.fixtures._decrypt_model_password", return_value=DummyPowerModel())
+
+        result = create_power_mng_from_model(DummyPowerModel())
+
+        assert isinstance(result, DummyPowerMngClass)
+        assert result.kwargs["password"] == "plain_pass"
+
+    def test_try_decrypt_secret_returns_original_for_none(self, mocker):
+        cipher = mocker.Mock()
+
+        result = _try_decrypt_secret(None, cipher)
+
+        assert result is None
+
+    def test_decrypt_model_password_when_no_encryption_key_returns_model(self, mocker):
+        class DummyModel:
+            def __init__(self):
+                self.password = SecretStr("encrypted")
+
+        model = DummyModel()
+        mocker.patch("pytest_mfd_config.fixtures._get_encryption_obj", side_effect=PyTestMFDConfigException("no key"))
+
+        result = _decrypt_model_password(model, field_name="password")
+
+        assert result is model
+
+    def test_decrypt_switch_password_when_no_encryption_key_returns_original(self, mocker):
+        switch_model = mocker.Mock(spec=SwitchModel)
+        switch_model.mng_password = SecretStr("encrypted")
+        switch_model.enable_password = None
+        switch_model.mng_ip_address = "10.0.0.1"
+
+        mocker.patch("pytest_mfd_config.fixtures._get_encryption_obj", side_effect=PyTestMFDConfigException("no key"))
+
+        result = _decrypt_switch_password(switch_model)
+
+        assert result is switch_model
+
+    def test_create_switch_from_model_uses_decrypted_switch_model(self, mocker):
+        class DummySwitchConnection:
+            pass
+
+        class DummySwitchClass:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+
+        dummy_mod = types.ModuleType("mfd_switchmanagement")
+        dummy_mod.SSHSwitchConnection = DummySwitchConnection
+        dummy_mod.CiscoAPIConnection = DummySwitchConnection
+        dummy_mod.DummySwitch = DummySwitchClass
+        mocker.patch.dict(sys.modules, {"mfd_switchmanagement": dummy_mod})
+
+        switch_model = mocker.Mock()
+        switch_model.connection_type = "SSHSwitchConnection"
+        switch_model.switch_type = "DummySwitch"
+        switch_model.mng_ip_address = "10.0.0.1"
+        switch_model.mng_user = "admin"
+        switch_model.mng_password = SecretStr("pass")
+        switch_model.enable_password = SecretStr("enable")
+        switch_model.ssh_key_file = None
+        switch_model.use_ssh_key = None
+        switch_model.device_type = None
+        switch_model.auth_timeout = None
+
+        decrypt_switch_mock = mocker.patch(
+            "pytest_mfd_config.fixtures._decrypt_switch_password", return_value=switch_model
+        )
+
+        result = create_switch_from_model(switch_model)
+
+        decrypt_switch_mock.assert_called_once_with(switch_model)
+        assert isinstance(result, DummySwitchClass)
+        assert result.kwargs["password"] == "pass"
+
+    def test_establish_connection_with_mac_uses_osd_controller_factory(self, mocker):
+        class DummyConnectionClass:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+
+        dummy_connect_mod = types.ModuleType("mfd_connect")
+        dummy_connect_mod.RPyCConnection = DummyConnectionClass
+        dummy_connect_mod.util = types.SimpleNamespace(EFI_SHELL_PROMPT_REGEX="prompt")
+        mocker.patch.dict(sys.modules, {"mfd_connect": dummy_connect_mod})
+
+        osd_controller = mocker.Mock()
+        osd_controller.does_host_exist.return_value = True
+        osd_controller.get_host_ip.return_value = "10.10.10.10"
+        create_osd_mock = mocker.patch(
+            "pytest_mfd_config.fixtures.create_osd_controller_from_model", return_value=osd_controller
+        )
+
+        connection_model = ConnectionModel(
+            connection_type="RPyCConnection",
+            mac_address="aa:bb:cc:dd:ee:ff",
+            osd_details={"base_url": "http://osd"},
+            connection_options={"password": "secret"},
+        )
+        assert isinstance(connection_model.connection_options["password"], SecretStr)
+
+        result = _establish_connection(connection_model)
+
+        create_osd_mock.assert_called_once()
+        osd_controller.does_host_exist.assert_called_once_with("aa:bb:cc:dd:ee:ff")
+        osd_controller.get_host_ip.assert_called_once_with("aa:bb:cc:dd:ee:ff")
+        assert isinstance(result, DummyConnectionClass)
+        assert result.kwargs["ip"] == "10.10.10.10"
+        assert result.kwargs["password"] == "secret"
+
+    def test_establish_connection_with_mac_raises_if_host_missing(self, mocker):
+        class DummyConnectionClass:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+
+        dummy_connect_mod = types.ModuleType("mfd_connect")
+        dummy_connect_mod.RPyCConnection = DummyConnectionClass
+        mocker.patch.dict(sys.modules, {"mfd_connect": dummy_connect_mod})
+
+        osd_controller = mocker.Mock()
+        osd_controller.does_host_exist.return_value = False
+        mocker.patch("pytest_mfd_config.fixtures.create_osd_controller_from_model", return_value=osd_controller)
+
+        connection_model = ConnectionModel(
+            connection_type="RPyCConnection",
+            mac_address="aa:bb:cc:dd:ee:ff",
+            osd_details={"base_url": "http://osd"},
+        )
+
+        with pytest.raises(PyTestMFDConfigException, match="Passed OSD Host does not exist"):
+            _establish_connection(connection_model)
+
+    def test_hosts_fixture_creates_only_instantiated_hosts(self, mocker):
+        topology_model = mocker.Mock()
+        host_a = mocker.Mock(name="host_a", instantiate=True)
+        host_a.name = "host-a"
+        host_b = mocker.Mock(name="host_b", instantiate=False)
+        topology_model.hosts = [host_a, host_b]
+
+        created_host = mocker.Mock()
+        created_host.name = "host-a"
+        create_host = mocker.patch("pytest_mfd_config.fixtures.create_host_from_model", return_value=created_host)
+
+        result = hosts.__wrapped__(topology_model)
+
+        assert result == {"host-a": created_host}
+        create_host.assert_called_once_with(host_model=host_a)
+
+    def test_decrypt_host_password_decrypts_mng_password_field(self, mocker):
+        class DummyHost:
+            def __init__(self):
+                self.name = "sut-1"
+                self.mng_password = SecretStr("enc_mng")
+                self.connections = None
+
+            def model_copy(self, update):
+                copied = DummyHost()
+                for k, v in update.items():
+                    setattr(copied, k, v)
+                return copied
+
+        host_model = DummyHost()
+        cipher = mocker.Mock()
+        mocker.patch("pytest_mfd_config.fixtures._get_encryption_obj", return_value=cipher)
+        mocker.patch(
+            "pytest_mfd_config.fixtures._try_decrypt_secret",
+            side_effect=lambda value, _c: SecretStr("plain_mng") if value is host_model.mng_password else value,
+        )
+
+        result = _decrypt_host_password(host_model)
+
+        assert isinstance(result.mng_password, SecretStr)
+        assert result.mng_password.get_secret_value() == "plain_mng"


### PR DESCRIPTION
This pull request adds support for automatic decryption of password fields stored in encrypted (Fernet) form for multiple model types, improving security and simplifying usage. It introduces utility functions to handle decryption for `SwitchModel`, `PowerMngModel`, `OSDControllerModel`, and `HostModel`, and updates relevant object creation routines to transparently decrypt passwords when needed. Documentation and example files are updated to reflect and demonstrate the new behavior.

**Decryption support for model password fields:**

* Added automatic decryption of `mng_password` and `enable_password` fields in `SwitchModel` during switch object creation, using the `AMBER_ENCRYPTION_KEY` environment variable. If decryption is needed but the key is missing, a `PyTestMFDConfigException` is raised. [[1]](diffhunk://#diff-234326f3aff32075d7fc4524578a7a1ebf4d589e6184cb31205cd009fbed8494R357-R510) [[2]](diffhunk://#diff-234326f3aff32075d7fc4524578a7a1ebf4d589e6184cb31205cd009fbed8494R118-R119) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R470-R475)
* Implemented decryption for the `password` field in `PowerMngModel` and `OSDControllerModel` when creating respective objects. [[1]](diffhunk://#diff-234326f3aff32075d7fc4524578a7a1ebf4d589e6184cb31205cd009fbed8494R266-R269) [[2]](diffhunk://#diff-234326f3aff32075d7fc4524578a7a1ebf4d589e6184cb31205cd009fbed8494R284-R304) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R410-R416) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R439-R444)
* Improved decryption logic for `HostModel`, supporting both host-level and per-connection password fields, and refactored the code for clarity and robustness. [[1]](diffhunk://#diff-234326f3aff32075d7fc4524578a7a1ebf4d589e6184cb31205cd009fbed8494R357-R510) [[2]](diffhunk://#diff-234326f3aff32075d7fc4524578a7a1ebf4d589e6184cb31205cd009fbed8494L543-L590)

**Documentation and examples:**

* Updated `README.md` to document the new password decryption behavior for `SwitchModel`, `PowerMngModel`, and `OSDControllerModel`, including usage notes and error handling. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R410-R416) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R439-R444) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R470-R475)
* Enhanced the example topology YAML file to show usage of encrypted secrets for host, switch, and power management passwords.

**Fixture API improvements:**

* Added a new fixture function `create_osd_controller_from_model` for consistent OSD controller object creation with decryption support. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R104) [[2]](diffhunk://#diff-234326f3aff32075d7fc4524578a7a1ebf4d589e6184cb31205cd009fbed8494R284-R304) [[3]](diffhunk://#diff-234326f3aff32075d7fc4524578a7a1ebf4d589e6184cb31205cd009fbed8494L218-R220)

These changes make it easier and safer to manage secrets in test configurations by supporting encrypted password fields throughout the configuration models.

Berta testing:
https://epg-framework-igk-berta-04.igk.intel.com/task/513773
<img width="259" height="181" alt="image" src="https://github.com/user-attachments/assets/a1066560-95cc-4ed2-b7b7-8b06dbcffc2a" />

